### PR TITLE
Include timezone and GMT offset in announcements

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,5 +2,6 @@ highlighter: rouge
 lsi: false
 markdown: kramdown
 safe: true
+timezone: America/New_York
 poole:
   word_separator: "-"

--- a/_includes/time.html
+++ b/_includes/time.html
@@ -1,6 +1,6 @@
 <p>
   <date datetime="{{ page.scheduled }}">
     {{ page.scheduled | date:"%A, %b %-d, %Y" }}<br />
-    {{ page.scheduled | date:"%-I:%M %p" }}
+    {{ page.scheduled | date:"%-I:%M %p %Z (GMT%z)" }}
   </date>
 </p>


### PR DESCRIPTION
Since the meeting's been online we're often joined by folks in non-ET timezones. To make scheduling easier for them, we ought to include the event's timezone and GMT offset in the announcement.

This adds the timezone and GMT offset to event announcements, like so:

> Monday, May 3, 2021
> 7:00 PM EDT (GMT-0400)

It explicitly sets the site's timezone to `America/New_York` to ensure that, even if the site is built on machines with different timezones, it'll treat timestamps as being in ET.

Manual testing suggests that daylight savings time works the way we'd expect.